### PR TITLE
Store references to callback objects to prevent garbage collection.

### DIFF
--- a/addon/adb-blocking-native.js
+++ b/addon/adb-blocking-native.js
@@ -91,6 +91,8 @@ module.exports = {
     let close_handle_func;
     if (platform === "winnt") {
       let bridge = function close_bridge() {
+        // Reference the callback object here so it is not garbage collected.
+        close_handle_func = null;
         let f = I.use("AdbCloseHandle");
         // call the real DLL function with the arguments to the bridge call
         return f.apply(f, arguments);

--- a/addon/adb-device-poll-thread.js
+++ b/addon/adb-device-poll-thread.js
@@ -32,7 +32,7 @@ const I = new Instantiator;
 let libadb = null;
 let winusbPath_ = null;
 let getLastError = function() { return 0; };
-let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
+let jsMsgCallback = JsMsgType.ptr(CommonMessageHandler(worker, console, function(channel, args) {
   switch(channel) {
     case "get-last-error":
       return JsMessage.pack(getLastError(), Number);
@@ -44,7 +44,7 @@ let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
   }
 
   return JsMessage.pack(-1, Number);
-});
+}));
 
 worker.once("init", function({ winusbPath, libPath, driversPath, platform }) {
   libadb = ctypes.open(libPath);
@@ -56,7 +56,7 @@ worker.once("init", function({ winusbPath, libPath, driversPath, platform }) {
                   args: [ JsMsgType.ptr ]
                 }, libadb);
 
-  install_js_msg(JsMsgType.ptr(jsMsgFn));
+  install_js_msg(jsMsgCallback);
 
   // on Linux, fallback to pthreads here
   if (platform === "linux") {

--- a/addon/adb-io-thread-spawner.js
+++ b/addon/adb-io-thread-spawner.js
@@ -30,7 +30,7 @@ const console = new Console(worker);
 let I = null;
 let libadb = null;
 let getLastError = function() { return 0; };
-let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
+let jsMsgCallback = JsMsgType.ptr(CommonMessageHandler(worker, console, function(channel, args) {
   switch(channel) {
     case "get-last-error":
       return JsMessage.pack(getLastError(), Number);
@@ -39,7 +39,7 @@ let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
   }
 
   return JsMessage.pack(-1, Number);
-});
+}));
 
 worker.once("init", function({ libPath, driversPath, threadName, t_ptrS, platform }) {
   I = new Instantiator();
@@ -54,7 +54,7 @@ worker.once("init", function({ libPath, driversPath, threadName, t_ptrS, platfor
                   args: [ JsMsgType.ptr ]
                 }, libadb);
 
-  install_js_msg(JsMsgType.ptr(jsMsgFn));
+  install_js_msg(jsMsgCallback);
 
   if (platform === "winnt") {
     const libadbdrivers = ctypes.open(driversPath);

--- a/addon/adb-io-thread.js
+++ b/addon/adb-io-thread.js
@@ -30,14 +30,14 @@ const console = new Console(worker);
 let I = null;
 let libadb = null;
 let io;
-let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
+let jsMsgCallback = JsMsgType.ptr(CommonMessageHandler(worker, console, function(channel, args) {
   switch(channel) {
     default:
       console.log("Unknown message: " + channel);
   }
 
   return JsMessage.pack(-1, Number);
-});
+}));
 
 worker.once("init", function({ libPath }) {
   I = new Instantiator();
@@ -52,7 +52,7 @@ worker.once("init", function({ libPath }) {
                   args: [ JsMsgType.ptr ]
                 }, libadb);
 
-  install_js_msg(JsMsgType.ptr(jsMsgFn));
+  install_js_msg(jsMsgCallback);
 });
 
 worker.listen("readStringFully", function({ fd, tag }) {

--- a/addon/adb-server-thread.js
+++ b/addon/adb-server-thread.js
@@ -30,7 +30,7 @@ let I = null;
 let libadb = null;
 let libPath_;
 
-let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
+let jsMsgCallback = JsMsgType.ptr(CommonMessageHandler(worker, console, function(channel, args) {
   switch(channel) {
     case "device-update":
       let [updates] = JsMessage.unpack(args, ctypes.char.ptr);
@@ -78,7 +78,7 @@ let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
       console.log("Unknown message: " + channel);
       return JsMessage.pack(-1, Number);
   }
-});
+}));
 
 worker.once("init", function({ libPath }) {
   libPath_ = libPath;
@@ -112,7 +112,7 @@ worker.once("init", function({ libPath }) {
                   args: [ JsMsgType.ptr ]
                 }, libadb);
 
-  install_js_msg(JsMsgType.ptr(jsMsgFn));
+  install_js_msg(jsMsgCallback);
 });
 
 worker.once("start", function({ port, log_path }) {

--- a/addon/adb-utility-thread.js
+++ b/addon/adb-utility-thread.js
@@ -26,14 +26,14 @@ const console = new Console(worker);
 let I = null;
 let libadb = null;
 let platform_ = null;
-let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
+let jsMsgCallback = JsMsgType.ptr(CommonMessageHandler(worker, console, function(channel, args) {
   switch(channel) {
     default:
       console.log("Unknown message: " + channel);
   }
 
   return JsMessage.pack(-1, Number);
-});
+}));
 
 worker.listen("init", function({ libPath, driversPath, platform }) {
   platform_ = platform;
@@ -53,7 +53,7 @@ worker.listen("init", function({ libPath, driversPath, platform }) {
                   args: [ JsMsgType.ptr ]
                 }, libadb);
 
-  install_js_msg(JsMsgType.ptr(jsMsgFn));
+  install_js_msg(jsMsgCallback);
 });
 
 worker.listen("query", function({ service }) {

--- a/addon/ctypes-bridge-builder.js
+++ b/addon/ctypes-bridge-builder.js
@@ -59,17 +59,18 @@
       this._zipWithIndex(bridge_body).forEach((function bridgeFunc([obj, i]) {
         // grab the name of the function
         for (let k in obj) {
-          // store the bridge to prevent premature garbage collection
-          ref[k] = (function bridgeCall() {
+          // Store the bridge callback object to prevent premature garbage
+          // collection.
+          ref[k] = bridge_funcs[i][k].ptr(() => {
             // get a reference to the actual DLL call
             let f = this.I.use(k);
             // call the real DLL function with the arguments to the bridge call
             let res = f.apply(f, arguments);
             this.saved_errno = ctypes.winLastError;
             return res;
-          }).bind(this);
+          });
           // install this callback in the bridge struct
-          bridge[k] = bridge_funcs[i][k].ptr(ref[k]);
+          bridge[k] = ref[k];
         }
         return null; // to get rid of func not returning value warning
       }).bind(this));

--- a/addon/test/test-js-message.js
+++ b/addon/test/test-js-message.js
@@ -34,7 +34,7 @@ let libPath = URL.toFilename(self.data.url(platformDir + "/adb/libtest" + extens
 let hasLib;
 let libtest;
 
-let jsMsgFn = function js_msg(channel, args) {
+let jsMsgCallback = JsMsgType.ptr(function js_msg(channel, args) {
   switch (channel.readString()) {
     case "test1":
       let [x, y] = JsMessage.unpack(args, ctypes.int, ctypes.int);
@@ -45,7 +45,7 @@ let jsMsgFn = function js_msg(channel, args) {
     default:
       return JsMessage.pack(-1, Number);
   }
-};
+});
 
 exports["test a if libtest exists"] = function(assert, done) {
   hasLib = File.exists(libPath);
@@ -69,7 +69,7 @@ exports["test b init"] = function(assert, done) {
                   args: [ JsMsgType.ptr ]
                 }, libtest);
 
-  install_js_msg(JsMsgType.ptr(jsMsgFn));
+  install_js_msg(jsMsgCallback);
 
   I.declare({ name: "call_test1",
               returns: ctypes.int,


### PR DESCRIPTION
As warned in https://developer.mozilla.org/en-US/docs/Mozilla/js-ctypes/js-ctypes_reference/Callbacks the callback objects must be stored so they are not GC'ed.

Should fix crashes on windows and possibly others. Steps to crash firefox on windows:
1) start app manager w/ liadb
2) connect to phone
3) open about:memory and run GC

I've added comments to most of the lines since it seems a bit strange to create a variable that is only used once on the next line.
