### PR TITLE
update to latest version of libadb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ifndef PLATFORM
   endif
 endif
 
-LIBADB_VERSION = 0.3
+LIBADB_VERSION = 0.4
 
 # The location of libadb for making ADB. Set this variable to "local" to build 
 # libadb.{so, dll} from source locally. Set to "remote" to grab prebuilt ADB 


### PR DESCRIPTION
@ochameau: this updates the version of libadb that `make LIBADB_LOCATION=remote` downloads from 0.3 to 0.4, which is the latest version of the library. There are no code changes here, because the code in android-tools/ is already up-to-date, so `make LIBADB_LOCATION=local` already builds the latest version locally. This merely updates the build variable.

Note that @bkase and I also recently reviewed and merged @brendandahl's fixes for that Windows crasher. But those changes are all in JS, so they don't require rebuilding the library. We still have a performance/CPU utilization issue with the wait timer on Windows, and we need to work out the library lifecycle issues, but then we should be ready to advertise libadb to a larger audience and get folks using it!
