### PR TITLE
make 'make package' package the helper addon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ run:
 	cd addon-sdk && . bin/activate && cd ../helper && cfx run --package-path ../addon/ $(BIN_ARG) $(PROFILE_ARG)
 
 package:
-	cd addon-sdk && . bin/activate && cd ../addon && cfx xpi
+	cd addon-sdk && . bin/activate && cd ../helper && cfx xpi --package-path ../addon/
 
 test:
 	cd addon-sdk && . bin/activate && cd ../addon && cfx test --verbose $(BIN_ARG) $(TEST_ARG) $(PROFILE_ARG)


### PR DESCRIPTION
`make package` fails with an error:

```
11-05 14:50 > make package
cd addon-sdk && . bin/activate && cd ../addon && cfx xpi
Welcome to the Add-on SDK. Run 'cfx docs' for assistance.
package.json does not have a 'main' entry.
make: *** [package] Error 1
```

I think that's because it's trying to `cfx xpi` in the _addon/_ directory, which is now just a package of modules, instead of the _helper/_ directory, which contains the _main.js_ and _package.json_ files for the helper addon.

If so, then this is the right fix, although I haven't tested resultant addon package.

@ochameau does this look correct to you?
