### PR TITLE
Fix firefox crash when command line adb is started.

### DIFF
--- a/addon/adb.js
+++ b/addon/adb.js
@@ -205,6 +205,8 @@ exports = module.exports = {
   }
 };
 
+context.close = exports.close;
+
 function restart_helper() {
   context.restart = exports.restart;
 }

--- a/addon/common-message-handler.js
+++ b/addon/common-message-handler.js
@@ -30,6 +30,9 @@
           case "restart-adb":
             worker.emitAndForget("restart-me", { });
             return JsMessage.pack(1, Number);
+          case "close-adb":
+            worker.emitAndForget("close-me", { });
+            return JsMessage.pack(1, Number);
           default:
             return andThen(channel, args);
         }

--- a/addon/evented-chrome-worker.js
+++ b/addon/evented-chrome-worker.js
@@ -93,6 +93,9 @@
         this._restartIdx = this.listen("restart-me", (function restart_me() {
           this.context.restart();
         }).bind(this));
+        this._closeIdx = this.listen("close-me", (function close_me() {
+          this.context.close();
+        }).bind(this));
       });
     } else {
 
@@ -179,6 +182,7 @@
       this.freeListener("_task", this._taskIdx);
       this.freeListener("log", this._logIdx);
       this.freeListener("restart-me", this._restartIdx);
+      this.freeListener("close-me", this._closeIdx);
       this.worker.terminate();
       return this;
     },

--- a/android-tools/adb-bin/adb.cpp
+++ b/android-tools/adb-bin/adb.cpp
@@ -1384,8 +1384,8 @@ int handle_host_request(char *service, transport_type ttype, char* serial, int r
         fprintf(stderr,"adb server killed by remote request\n");
         fflush(stdout);
         adb_write(reply_fd, "OKAY", 4);
-        usb_cleanup();
-        exit(0);
+        send_js_msg("close-adb", NULL);
+        return 0;
     }
 
 #if ADB_HOST

--- a/android-tools/adb-bin/sockets.c
+++ b/android-tools/adb-bin/sockets.c
@@ -738,7 +738,7 @@ static int smart_socket_enqueue(asocket *s, apacket *p)
             ** and tear down here.
             */
         s2 = create_host_service_socket(service, serial);
-        D( "SS(%d): attempted to create host service socket\n", s2->id);
+        D( "SS(%d): attempted to create host service socket\n", s->id);
         if(s2 == 0) {
             D( "SS(%d): couldn't create host service '%s'\n", s->id, service );
             sendfailmsg(s->peer->fd, "unknown host service");


### PR DESCRIPTION
This removes the exit(0) when adb tells us to close and instead triggers our close function.  Unfortunately, once closed the app manager connection doesn't currently work again until firefox is restarted.  Also, the device doesn't show up to adb until it is replugged.

Next I'm going to try to get it into a state where close() and start() can be called and everything will work again.
