### PR TITLE
Only cleanup thread array lists if they have been allocated.

### DIFF
--- a/addon/test/test-main.js
+++ b/addon/test/test-main.js
@@ -249,6 +249,13 @@ exports = (function(exports) {
   };
   */
 
+  exports["test shutdown and start"] = function (assert, done) {
+    ADB.close();
+    ADB.start();
+    assert.pass("No crash.");
+    done();
+  };
+
   exports["test zz after"] = function(assert, done) {
     if (ADB.didRunInitially) {
       try {


### PR DESCRIPTION
Fixes a crash when close and start happen back to back.
