### PR TITLE
Fix replug shutdown crash.

### DIFF
--- a/android-tools/adb-bin/transport.cpp
+++ b/android-tools/adb-bin/transport.cpp
@@ -292,6 +292,9 @@ void kill_io_pump(atransport * t, bool (*close_handle_func)(ADBAPIHANDLE)){
         // Nothing to do.
         return;
     }
+    if (!t->kicked) {
+        return;
+    }
 #ifdef WIN32
     usb_kick(t->usb, close_handle_func);
 #else


### PR DESCRIPTION
Fixes #22 and tests when a device is plugged in.

I'm still not happy with the close/open code since it returns before things are really ready/shtudown, but this fixes any known issues.
