### PR TITLE
Bug 957164 - Support full refresh in case server dies. r=ochameau

### DIFF
--- a/helper/lib/main.js
+++ b/helper/lib/main.js
@@ -13,13 +13,23 @@ Cu.import("resource://gre/modules/Services.jsm");
 
 Devices.helperAddonInstalled = true;
 
+// start automatically start tracking devices
+adb.start();
+
+// Ensure devices list is up to date, restarting the server if needed
+function refresh() {
+  if (!adb.ready) {
+    adb.restart();
+  }
+}
+
+Devices.on("refresh", refresh);
+
 unload.when(function () {
+  Devices.off("refresh", refresh);
   Devices.helperAddonInstalled = false;
   adb.close();
 });
-
-// start automatically start tracking devices
-adb.start();
 
 let idToName = new Map();
 


### PR DESCRIPTION
For UI v2, Paul would like to support scanning when you open a list. So, here we listen for a new "refresh" event. If libadb's server is no longer running for some reason (like when you have run console ADB in between), we restart and re-list the devices.
